### PR TITLE
Whole data test case for extract.features and benchmarking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: This is a customized fork of the original work from Tianwei Yu.
         It takes the adaptive processing of LC/MS metabolomics data further
         with focus on high resolution MS for both LC and GC applications.
 Depends: R (>= 3.50), MASS, mzR, splines, doParallel, foreach,
-        snow, dplyr, tidyr, stringr, tibble, tools, arrow
+        snow, dplyr, tidyr, stringr, tibble, tools, arrow, microbenchmark
 biocViews: Technology, MassSpectrometry
 License: GPL-2
 LazyLoad: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,12 +9,12 @@ Description: This is a customized fork of the original work from Tianwei Yu.
         It takes the adaptive processing of LC/MS metabolomics data further
         with focus on high resolution MS for both LC and GC applications.
 Depends: R (>= 3.50), MASS, mzR, splines, doParallel, foreach,
-        snow, dplyr, tidyr, stringr, tibble, tools, arrow, microbenchmark
+        snow, dplyr, tidyr, stringr, tibble, tools, arrow
 biocViews: Technology, MassSpectrometry
 License: GPL-2
 LazyLoad: yes
 NeedsCompilation: no
 Suggests: 
-    dataCompareR, testthat (>= 3.0.0)
+    dataCompareR, testthat (>= 3.0.0), microbenchmark
 Config/testthat/edition: 3
 RoxygenNote: 7.2.1

--- a/conda/environment-dev.yaml
+++ b/conda/environment-dev.yaml
@@ -35,3 +35,5 @@ dependencies:
   - r-patrick
   - radian
   - r-httpgd
+  - r-microbenchmark
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -63,7 +63,6 @@ requirements:
     - r-tidyr
     - r-stringr
     - r-tibble
-    - r-microbenchmark
 
 test:
   commands:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - r-dplyr
     - r-tidyr
     - r-stringr
+    - r-microbenchmark
 
   run:
     - r-base >=3.5
@@ -62,6 +63,7 @@ requirements:
     - r-tidyr
     - r-stringr
     - r-tibble
+    - r-microbenchmark
 
 test:
   commands:

--- a/tests/remote-files/extracted-whole.txt
+++ b/tests/remote-files/extracted-whole.txt
@@ -1,0 +1,6 @@
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/8_qc_no_dil_milliq.mzML
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/21_qc_no_dil_milliq.mzML
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/29_qc_no_dil_milliq.mzML
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/extracted/8_qc_no_dil_milliq.parquet  
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/extracted/21_qc_no_dil_milliq.parquet  
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/extracted/29_qc_no_dil_milliq.parquet

--- a/tests/remote-files/extracted-whole.txt
+++ b/tests/remote-files/extracted-whole.txt
@@ -1,6 +1,6 @@
-https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/8_qc_no_dil_milliq.mzML
-https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/21_qc_no_dil_milliq.mzML
-https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/29_qc_no_dil_milliq.mzML
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/8_qc_no_dil_milliq.mzml
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/21_qc_no_dil_milliq.mzml
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/input/29_qc_no_dil_milliq.mzml
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/extracted/8_qc_no_dil_milliq.parquet  
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/extracted/21_qc_no_dil_milliq.parquet  
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-aplcms/extracted/29_qc_no_dil_milliq.parquet

--- a/tests/testthat/test-benchmark-unsupervised.R
+++ b/tests/testthat/test-benchmark-unsupervised.R
@@ -1,0 +1,55 @@
+patrick::with_parameters_test_that(
+  "test benchmark",
+  {
+    if(skip){
+      skip("Disabled")
+    }
+
+    skip_on_ci()
+
+    testdata <- file.path("..", "testdata")
+
+    filenames <- lapply(filename, function(x) {
+      file.path(testdata, paste0(x, ".mzml"))
+    })
+
+    # CRAN limits the number of cores available to packages to 2
+    # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
+    chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
+
+    if (nzchar(chk) && chk == "TRUE") {
+      # use 2 cores in CRAN/Travis/AppVeyor
+      cluster <- 2L
+    } else {
+      # use all cores in devtools::test()
+      cluster <- parallel::detectCores()
+    }
+
+    if (!is(cluster, "cluster")) {
+      cluster <- parallel::makeCluster(cluster)
+      on.exit(parallel::stopCluster(cluster))
+    }
+
+    res <- microbenchmark::microbenchmark(
+      unsupervised = {
+          result <- unsupervised(unlist(filenames), cluster = cluster)
+      },
+      times = 10L
+    )
+
+    expected_path <- file.path(testdata, expected_filename)
+    expected <- arrow::read_parquet(expected_path)
+    expect_equal(result$recovered_feature_sample_table, expected)
+
+    cat("\n\n")
+    print(res)
+    cat("\n")
+  },
+  patrick::cases(
+    RCX_shortened = list(
+      filename = c("mbr_test0", "mbr_test1", "mbr_test2"),
+      expected_filename = "unsupervised_recovered_feature_sample_table.parquet",
+      skip = TRUE
+    )
+  )
+)

--- a/tests/testthat/test-benchmark.R
+++ b/tests/testthat/test-benchmark.R
@@ -1,6 +1,10 @@
 patrick::with_parameters_test_that(
   "test benchmark",
   {
+    if(skip){
+      skip("Disabled")
+    }
+
     skip_on_ci()
 
     testdata <- file.path("..", "testdata")
@@ -28,10 +32,6 @@ patrick::with_parameters_test_that(
     if (!is(cluster, "cluster")) {
       cluster <- parallel::makeCluster(cluster)
       on.exit(parallel::stopCluster(cluster))
-    }
-
-    if(skip){
-      skip("Disabled")
     }
 
     res <- microbenchmark::microbenchmark(

--- a/tests/testthat/test-benchmark.R
+++ b/tests/testthat/test-benchmark.R
@@ -1,0 +1,109 @@
+patrick::with_parameters_test_that(
+  "test benchmark",
+  {
+    skip_on_ci()
+
+    testdata <- file.path("..", "testdata")
+
+    filenames_extract <- lapply(files_extract, function(x) {
+      file.path(testdata, "input", paste0(x, ".mzML"))
+    })
+
+    filenames_unsupervised <- lapply(files_unsupervised, function(x) {
+      file.path(testdata, paste0(x, ".mzml"))
+    })
+
+    # CRAN limits the number of cores available to packages to 2
+    # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
+    chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
+
+    if (nzchar(chk) && chk == "TRUE") {
+      # use 2 cores in CRAN/Travis/AppVeyor
+      cluster <- 2L
+    } else {
+      # use all cores in devtools::test()
+      cluster <- parallel::detectCores()
+    }
+
+    if (!is(cluster, "cluster")) {
+      cluster <- parallel::makeCluster(cluster)
+      on.exit(parallel::stopCluster(cluster))
+    }
+
+    if(skip){
+      skip("Disabled")
+    }
+
+    res <- microbenchmark::microbenchmark(
+        unsupervised = {
+            result <- unsupervised(unlist(filenames_unsupervised), cluster = cluster)
+            expected <- arrow::read_parquet('../testdata/unsupervised_recovered_feature_sample_table.parquet')
+            expect_equal(result$recovered_feature_sample_table, expected)
+        },
+        extract_feature = {
+            actual <- extract_features(
+              filenames_extract,
+              cluster = cluster,
+              min_pres = min_pres,
+              min_run = min_run,
+              mz_tol = tol,
+              intensity_weighted = intensity_weighted,
+              sd_cut = sd_cut,
+              sigma_ratio_lim = sigma_ratio_lim,
+              baseline_correct = 0,
+              baseline_correct_noise_percentile = 0.05,
+              min_bandwidth = NA,
+              max_bandwidth = NA,
+              moment_power = 1,
+              BIC_factor = 2.0,
+              component_eliminate = 0.01,
+              peak_estim_method = "moment",
+              shape_model = "bi-Gaussian"
+            )
+            expected_extract_filenames <- lapply(files_extract, function(x) {
+              file.path(testdata, "extracted", paste0(x, ".parquet"))
+            })
+            expected <- lapply(expected_extract_filenames, arrow::read_parquet)
+            expected <- lapply(expected, as.data.frame)
+            actual <- unique(actual)
+            expected <- unique(expected)
+            keys <- c("mz", "pos", "sd1", "sd2")
+            actual <- lapply(actual, function(x) {
+              as.data.frame(x) |> dplyr::arrange_at(keys)
+            })
+            expected <- lapply(expected, function(x) {
+              as.data.frame(x) |> dplyr::arrange_at(keys)
+            })
+            for (i in seq_along(files_extract)) {
+              actual_i <- actual[[i]]
+              expected_i <- expected[[i]]
+              report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
+              dataCompareR::saveReport(report, reportName = files_extract[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
+              expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
+              incommon <- as.numeric(rownames(report$rowMatching$inboth))
+              subset_actual <- actual_i %>% dplyr::slice(incommon)
+              subset_expected <- expected_i %>% dplyr::slice(incommon)
+              expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
+            }
+      },
+        times = 10L
+    )
+
+    cat("\n\n")
+    print(res)
+    cat("\n")
+  },
+  patrick::cases(
+    RCX_shortened = list(
+      files_extract = c("RCX_06_shortened", "RCX_07_shortened", "RCX_08_shortened"),
+      files_unsupervised = c("mbr_test0", "mbr_test1", "mbr_test2"),
+      tol = 1e-05,
+      min_pres = 0.5,
+      min_run = 12,
+      intensity_weighted = FALSE,
+      sd_cut = c(0.01, 500),
+      sigma_ratio_lim = c(0.01, 100),
+      skip = TRUE
+    )
+  )
+)

--- a/tests/testthat/test-benchmark.R
+++ b/tests/testthat/test-benchmark.R
@@ -35,59 +35,61 @@ patrick::with_parameters_test_that(
     }
 
     res <- microbenchmark::microbenchmark(
-        unsupervised = {
-            result <- unsupervised(unlist(filenames_unsupervised), cluster = cluster)
-            expected <- arrow::read_parquet('../testdata/unsupervised_recovered_feature_sample_table.parquet')
-            expect_equal(result$recovered_feature_sample_table, expected)
-        },
-        extract_feature = {
-            actual <- extract_features(
-              filenames_extract,
-              cluster = cluster,
-              min_pres = min_pres,
-              min_run = min_run,
-              mz_tol = tol,
-              intensity_weighted = intensity_weighted,
-              sd_cut = sd_cut,
-              sigma_ratio_lim = sigma_ratio_lim,
-              baseline_correct = 0,
-              baseline_correct_noise_percentile = 0.05,
-              min_bandwidth = NA,
-              max_bandwidth = NA,
-              moment_power = 1,
-              BIC_factor = 2.0,
-              component_eliminate = 0.01,
-              peak_estim_method = "moment",
-              shape_model = "bi-Gaussian"
-            )
-            expected_extract_filenames <- lapply(files_extract, function(x) {
-              file.path(testdata, "extracted", paste0(x, ".parquet"))
-            })
-            expected <- lapply(expected_extract_filenames, arrow::read_parquet)
-            expected <- lapply(expected, as.data.frame)
-            actual <- unique(actual)
-            expected <- unique(expected)
-            keys <- c("mz", "pos", "sd1", "sd2")
-            actual <- lapply(actual, function(x) {
-              as.data.frame(x) |> dplyr::arrange_at(keys)
-            })
-            expected <- lapply(expected, function(x) {
-              as.data.frame(x) |> dplyr::arrange_at(keys)
-            })
-            for (i in seq_along(files_extract)) {
-              actual_i <- actual[[i]]
-              expected_i <- expected[[i]]
-              report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
-              dataCompareR::saveReport(report, reportName = files_extract[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
-              expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
-              incommon <- as.numeric(rownames(report$rowMatching$inboth))
-              subset_actual <- actual_i %>% dplyr::slice(incommon)
-              subset_expected <- expected_i %>% dplyr::slice(incommon)
-              expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
-            }
+      unsupervised = {
+          result <- unsupervised(unlist(filenames_unsupervised), cluster = cluster)
       },
-        times = 10L
+      extract_feature = {
+          actual <- extract_features(
+            filenames_extract,
+            cluster = cluster,
+            min_pres = min_pres,
+            min_run = min_run,
+            mz_tol = tol,
+            intensity_weighted = intensity_weighted,
+            sd_cut = sd_cut,
+            sigma_ratio_lim = sigma_ratio_lim,
+            baseline_correct = 0,
+            baseline_correct_noise_percentile = 0.05,
+            min_bandwidth = NA,
+            max_bandwidth = NA,
+            moment_power = 1,
+            BIC_factor = 2.0,
+            component_eliminate = 0.01,
+            peak_estim_method = "moment",
+            shape_model = "bi-Gaussian"
+          )
+      },
+      times = 10L
     )
+
+    expected <- arrow::read_parquet('../testdata/unsupervised_recovered_feature_sample_table.parquet')
+    expect_equal(result$recovered_feature_sample_table, expected)
+
+    expected_extract_filenames <- lapply(files_extract, function(x) {
+      file.path(testdata, "extracted", paste0(x, ".parquet"))
+    })
+    expected <- lapply(expected_extract_filenames, arrow::read_parquet)
+    expected <- lapply(expected, as.data.frame)
+    actual <- unique(actual)
+    expected <- unique(expected)
+    keys <- c("mz", "pos", "sd1", "sd2")
+    actual <- lapply(actual, function(x) {
+      as.data.frame(x) |> dplyr::arrange_at(keys)
+    })
+    expected <- lapply(expected, function(x) {
+      as.data.frame(x) |> dplyr::arrange_at(keys)
+    })
+    for (i in seq_along(files_extract)) {
+      actual_i <- actual[[i]]
+      expected_i <- expected[[i]]
+      report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
+      dataCompareR::saveReport(report, reportName = files_extract[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
+      expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
+      incommon <- as.numeric(rownames(report$rowMatching$inboth))
+      subset_actual <- actual_i %>% dplyr::slice(incommon)
+      subset_expected <- expected_i %>% dplyr::slice(incommon)
+      expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
+    }
 
     cat("\n\n")
     print(res)

--- a/tests/testthat/test-extract_features.R
+++ b/tests/testthat/test-extract_features.R
@@ -26,61 +26,63 @@ patrick::with_parameters_test_that(
       on.exit(parallel::stopCluster(cluster))
     }
 
-    actual <- extract_features(
-      filenames,
-      cluster = cluster,
-      min_pres = min_pres,
-      min_run = min_run,
-      mz_tol = tol,
-      intensity_weighted = intensity_weighted,
-      sd_cut = sd_cut,
-      sigma_ratio_lim = sigma_ratio_lim,
-      baseline_correct = 0,
-      baseline_correct_noise_percentile = 0.05,
-      min_bandwidth = NA,
-      max_bandwidth = NA,
-      moment_power = 1,
-      BIC_factor = 2.0,
-      component_eliminate = 0.01,
-      peak_estim_method = "moment",
-      shape_model = "bi-Gaussian"
-    )
+    if(!skip){
+      actual <- extract_features(
+        filenames,
+        cluster = cluster,
+        min_pres = min_pres,
+        min_run = min_run,
+        mz_tol = tol,
+        intensity_weighted = intensity_weighted,
+        sd_cut = sd_cut,
+        sigma_ratio_lim = sigma_ratio_lim,
+        baseline_correct = 0,
+        baseline_correct_noise_percentile = 0.05,
+        min_bandwidth = NA,
+        max_bandwidth = NA,
+        moment_power = 1,
+        BIC_factor = 2.0,
+        component_eliminate = 0.01,
+        peak_estim_method = "moment",
+        shape_model = "bi-Gaussian"
+      )
 
-    expected_filenames <- lapply(files, function(x) {
-      file.path(testdata, "extracted", paste0(x, ".parquet"))
-    })
-    
-    expected <- lapply(expected_filenames, arrow::read_parquet)
-    expected <- lapply(expected, as.data.frame)
+      expected_filenames <- lapply(files, function(x) {
+        file.path(testdata, "extracted", paste0(x, ".parquet"))
+      })
 
-    actual <- unique(actual)
-    expected <- unique(expected)
+      expected <- lapply(expected_filenames, arrow::read_parquet)
+      expected <- lapply(expected, as.data.frame)
 
-    keys <- c("mz", "pos", "sd1", "sd2")
+      actual <- unique(actual)
+      expected <- unique(expected)
 
-    actual <- lapply(actual, function(x) {
-      as.data.frame(x) |> dplyr::arrange_at(keys)
-    })
-    expected <- lapply(expected, function(x) {
-      as.data.frame(x) |> dplyr::arrange_at(keys)
-    })
+      keys <- c("mz", "pos", "sd1", "sd2")
+
+      actual <- lapply(actual, function(x) {
+        as.data.frame(x) |> dplyr::arrange_at(keys)
+      })
+      expected <- lapply(expected, function(x) {
+        as.data.frame(x) |> dplyr::arrange_at(keys)
+      })
 
 
-    for (i in seq_along(files)) {
-      actual_i <- actual[[i]]
-      expected_i <- expected[[i]]
+      for (i in seq_along(files)) {
+        actual_i <- actual[[i]]
+        expected_i <- expected[[i]]
 
-      report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
-      dataCompareR::saveReport(report, reportName = files[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
+        report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
+        dataCompareR::saveReport(report, reportName = files[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
 
-      expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
+        expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
 
-      incommon <- as.numeric(rownames(report$rowMatching$inboth))
+        incommon <- as.numeric(rownames(report$rowMatching$inboth))
 
-      subset_actual <- actual_i %>% dplyr::slice(incommon)
-      subset_expected <- expected_i %>% dplyr::slice(incommon)
+        subset_actual <- actual_i %>% dplyr::slice(incommon)
+        subset_expected <- expected_i %>% dplyr::slice(incommon)
 
-      expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
+        expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
+      }
     }
   },
   patrick::cases(
@@ -91,7 +93,18 @@ patrick::with_parameters_test_that(
       min_run = 12,
       intensity_weighted = FALSE,
       sd_cut = c(0.01, 500),
-      sigma_ratio_lim = c(0.01, 100)
+      sigma_ratio_lim = c(0.01, 100),
+      skip = FALSE
+    ),
+    qc_no_dil_milliq = list(
+      files = c("8_qc_no_dil_milliq", "21_qc_no_dil_milliq", "29_qc_no_dil_milliq"),
+      tol = 1e-05,
+      min_pres = 0.5,
+      min_run = 12,
+      intensity_weighted = FALSE,
+      sd_cut = c(0.01, 500),
+      sigma_ratio_lim = c(0.01, 100),
+      skip = TRUE
     )
   )
 )

--- a/tests/testthat/test-extract_features.R
+++ b/tests/testthat/test-extract_features.R
@@ -26,63 +26,53 @@ patrick::with_parameters_test_that(
       on.exit(parallel::stopCluster(cluster))
     }
 
-    if(!skip){
-      actual <- extract_features(
-        filenames,
-        cluster = cluster,
-        min_pres = min_pres,
-        min_run = min_run,
-        mz_tol = tol,
-        intensity_weighted = intensity_weighted,
-        sd_cut = sd_cut,
-        sigma_ratio_lim = sigma_ratio_lim,
-        baseline_correct = 0,
-        baseline_correct_noise_percentile = 0.05,
-        min_bandwidth = NA,
-        max_bandwidth = NA,
-        moment_power = 1,
-        BIC_factor = 2.0,
-        component_eliminate = 0.01,
-        peak_estim_method = "moment",
-        shape_model = "bi-Gaussian"
-      )
+    if(skip){
+      skip("skipping whole data test case")
+    }
 
-      expected_filenames <- lapply(files, function(x) {
-        file.path(testdata, "extracted", paste0(x, ".parquet"))
-      })
-
-      expected <- lapply(expected_filenames, arrow::read_parquet)
-      expected <- lapply(expected, as.data.frame)
-
-      actual <- unique(actual)
-      expected <- unique(expected)
-
-      keys <- c("mz", "pos", "sd1", "sd2")
-
-      actual <- lapply(actual, function(x) {
-        as.data.frame(x) |> dplyr::arrange_at(keys)
-      })
-      expected <- lapply(expected, function(x) {
-        as.data.frame(x) |> dplyr::arrange_at(keys)
-      })
-
-
-      for (i in seq_along(files)) {
-        actual_i <- actual[[i]]
-        expected_i <- expected[[i]]
-
-        report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
-        dataCompareR::saveReport(report, reportName = files[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
-
-        expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
-
-        incommon <- as.numeric(rownames(report$rowMatching$inboth))
-
-        subset_actual <- actual_i %>% dplyr::slice(incommon)
-        subset_expected <- expected_i %>% dplyr::slice(incommon)
-
-        expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
-      }
+    actual <- extract_features(
+      filenames,
+      cluster = cluster,
+      min_pres = min_pres,
+      min_run = min_run,
+      mz_tol = tol,
+      intensity_weighted = intensity_weighted,
+      sd_cut = sd_cut,
+      sigma_ratio_lim = sigma_ratio_lim,
+      baseline_correct = 0,
+      baseline_correct_noise_percentile = 0.05,
+      min_bandwidth = NA,
+      max_bandwidth = NA,
+      moment_power = 1,
+      BIC_factor = 2.0,
+      component_eliminate = 0.01,
+      peak_estim_method = "moment",
+      shape_model = "bi-Gaussian"
+    )
+    expected_filenames <- lapply(files, function(x) {
+      file.path(testdata, "extracted", paste0(x, ".parquet"))
+    })
+    expected <- lapply(expected_filenames, arrow::read_parquet)
+    expected <- lapply(expected, as.data.frame)
+    actual <- unique(actual)
+    expected <- unique(expected)
+    keys <- c("mz", "pos", "sd1", "sd2")
+    actual <- lapply(actual, function(x) {
+      as.data.frame(x) |> dplyr::arrange_at(keys)
+    })
+    expected <- lapply(expected, function(x) {
+      as.data.frame(x) |> dplyr::arrange_at(keys)
+    })
+    for (i in seq_along(files)) {
+      actual_i <- actual[[i]]
+      expected_i <- expected[[i]]
+      report <- dataCompareR::rCompare(actual_i, expected_i, keys = keys, roundDigits = 4, mismatches = 100000)
+      dataCompareR::saveReport(report, reportName = files[[i]], showInViewer = FALSE, HTMLReport = FALSE, mismatchCount = 10000)
+      expect_true(nrow(report$rowMatching$inboth) >= 0.9 * nrow(expected_i))
+      incommon <- as.numeric(rownames(report$rowMatching$inboth))
+      subset_actual <- actual_i %>% dplyr::slice(incommon)
+      subset_expected <- expected_i %>% dplyr::slice(incommon)
+      expect_equal(subset_actual$area, subset_expected$area, tolerance = 0.01 * max(subset_expected$area))
     }
   },
   patrick::cases(

--- a/tests/testthat/test-extract_features.R
+++ b/tests/testthat/test-extract_features.R
@@ -6,7 +6,7 @@ patrick::with_parameters_test_that(
     testdata <- file.path("..", "testdata")
 
     filenames <- lapply(files, function(x) {
-      file.path(testdata, "input", paste0(x, ".mzML"))
+      file.path(testdata, "input", x)
     })
 
     # CRAN limits the number of cores available to packages to 2
@@ -49,8 +49,8 @@ patrick::with_parameters_test_that(
       peak_estim_method = "moment",
       shape_model = "bi-Gaussian"
     )
-    expected_filenames <- lapply(files, function(x) {
-      file.path(testdata, "extracted", paste0(x, ".parquet"))
+    expected_filenames <- lapply(expected_files, function(x) {
+      file.path(testdata, "extracted", x)
     })
     expected <- lapply(expected_filenames, arrow::read_parquet)
     expected <- lapply(expected, as.data.frame)
@@ -77,7 +77,8 @@ patrick::with_parameters_test_that(
   },
   patrick::cases(
     RCX_shortened = list(
-      files = c("RCX_06_shortened", "RCX_07_shortened", "RCX_08_shortened"),
+      files = c("RCX_06_shortened.mzML", "RCX_07_shortened.mzML", "RCX_08_shortened.mzML"),
+      expected_files = c("RCX_06_shortened.parquet", "RCX_07_shortened.parquet", "RCX_08_shortened.parquet"),
       tol = 1e-05,
       min_pres = 0.5,
       min_run = 12,
@@ -87,7 +88,8 @@ patrick::with_parameters_test_that(
       skip = FALSE
     ),
     qc_no_dil_milliq = list(
-      files = c("8_qc_no_dil_milliq", "21_qc_no_dil_milliq", "29_qc_no_dil_milliq"),
+      files = c("8_qc_no_dil_milliq.mzml", "21_qc_no_dil_milliq.mzml", "29_qc_no_dil_milliq.mzml"),
+      expected_files = c("8_qc_no_dil_milliq.parquet", "21_qc_no_dil_milliq.parquet", "29_qc_no_dil_milliq.parquet"),
       tol = 1e-05,
       min_pres = 0.5,
       min_run = 12,

--- a/tests/testthat/test-extract_features.R
+++ b/tests/testthat/test-extract_features.R
@@ -2,7 +2,10 @@ patrick::with_parameters_test_that(
   "extract single feature works",
   {
     skip_on_ci()
-
+    if(skip){
+      skip("skipping whole data test case")
+    }
+    
     testdata <- file.path("..", "testdata")
 
     filenames <- lapply(files, function(x) {
@@ -24,10 +27,6 @@ patrick::with_parameters_test_that(
     if (!is(cluster, "cluster")) {
       cluster <- parallel::makeCluster(cluster)
       on.exit(parallel::stopCluster(cluster))
-    }
-
-    if(skip){
-      skip("skipping whole data test case")
     }
 
     actual <- extract_features(


### PR DESCRIPTION
This PR includes the following:

- Implemented whole data test case for extract_features. skipped by default. #89 
- implemented test for benchmarking unsupervised and extract_features. Disabled by default, default repetition 10 #83 
- added extracted-whole.txt file to fetch remote file (for the whole data)
- added microbenchmark in description, meta.yaml, and environment-dev.yaml file.

closes #89 closes #83