### PR TITLE
Used get_num_workers in all test cases

### DIFF
--- a/tests/testthat/test-benchmark-extract_features.R
+++ b/tests/testthat/test-benchmark-extract_features.R
@@ -1,7 +1,7 @@
 patrick::with_parameters_test_that(
   "test benchmark",
   {
-    if(skip){
+    if (skip) {
       skip("Disabled")
     }
 
@@ -13,17 +13,7 @@ patrick::with_parameters_test_that(
       file.path(testdata, "input", paste0(x, ".mzML"))
     })
 
-    # CRAN limits the number of cores available to packages to 2
-    # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
-    chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
-
-    if (nzchar(chk) && chk == "TRUE") {
-      # use 2 cores in CRAN/Travis/AppVeyor
-      cluster <- 2L
-    } else {
-      # use all cores in devtools::test()
-      cluster <- parallel::detectCores()
-    }
+    cluster <- get_num_workers()
 
     if (!is(cluster, "cluster")) {
       cluster <- parallel::makeCluster(cluster)
@@ -32,25 +22,25 @@ patrick::with_parameters_test_that(
 
     res <- microbenchmark::microbenchmark(
       extract_feature = {
-          actual <- extract_features(
-            filenames,
-            cluster = cluster,
-            min_pres = min_pres,
-            min_run = min_run,
-            mz_tol = tol,
-            intensity_weighted = intensity_weighted,
-            sd_cut = sd_cut,
-            sigma_ratio_lim = sigma_ratio_lim,
-            baseline_correct = 0,
-            baseline_correct_noise_percentile = 0.05,
-            min_bandwidth = NA,
-            max_bandwidth = NA,
-            moment_power = 1,
-            BIC_factor = 2.0,
-            component_eliminate = 0.01,
-            peak_estim_method = "moment",
-            shape_model = "bi-Gaussian"
-          )
+        actual <- extract_features(
+          cluster = cluster,
+          filenames,
+          min_presence = min_presence,
+          min_elution_length = min_elution_length,
+          mz_tol = mz_tol,
+          baseline_correct = 0,
+          baseline_correct_noise_percentile = 0.05,
+          intensity_weighted = intensity_weighted,
+          min_bandwidth = NA,
+          max_bandwidth = NA,
+          sd_cut = sd_cut,
+          sigma_ratio_lim = sigma_ratio_lim,
+          shape_model = "bi-Gaussian",
+          peak_estim_method = "moment",
+          component_eliminate = 0.01,
+          moment_power = 1,
+          BIC_factor = 2.0
+        )
       },
       times = 10L
     )
@@ -88,9 +78,9 @@ patrick::with_parameters_test_that(
   patrick::cases(
     RCX_shortened = list(
       filename = c("RCX_06_shortened", "RCX_07_shortened", "RCX_08_shortened"),
-      tol = 1e-05,
-      min_pres = 0.5,
-      min_run = 12,
+      mz_tol = 1e-05,
+      min_presence = 0.5,
+      min_elution_length = 12,
       intensity_weighted = FALSE,
       sd_cut = c(0.01, 500),
       sigma_ratio_lim = c(0.01, 100),

--- a/tests/testthat/test-benchmark-unsupervised.R
+++ b/tests/testthat/test-benchmark-unsupervised.R
@@ -1,7 +1,7 @@
 patrick::with_parameters_test_that(
   "test benchmark",
   {
-    if(skip){
+    if (skip) {
       skip("Disabled")
     }
 
@@ -10,20 +10,10 @@ patrick::with_parameters_test_that(
     testdata <- file.path("..", "testdata")
 
     filenames <- lapply(filename, function(x) {
-      file.path(testdata, paste0(x, ".mzml"))
+      file.path(testdata, "input", paste0(x, ".mzml"))
     })
 
-    # CRAN limits the number of cores available to packages to 2
-    # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
-    chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
-
-    if (nzchar(chk) && chk == "TRUE") {
-      # use 2 cores in CRAN/Travis/AppVeyor
-      cluster <- 2L
-    } else {
-      # use all cores in devtools::test()
-      cluster <- parallel::detectCores()
-    }
+    cluster <- get_num_workers()
 
     if (!is(cluster, "cluster")) {
       cluster <- parallel::makeCluster(cluster)
@@ -32,7 +22,7 @@ patrick::with_parameters_test_that(
 
     res <- microbenchmark::microbenchmark(
       unsupervised = {
-          result <- unsupervised(unlist(filenames), cluster = cluster)
+        result <- unsupervised(unlist(filenames), cluster = cluster)
       },
       times = 10L
     )

--- a/tests/testthat/test-extract_features.R
+++ b/tests/testthat/test-extract_features.R
@@ -2,27 +2,17 @@ patrick::with_parameters_test_that(
   "extract single feature works",
   {
     skip_on_ci()
-    if(skip){
+    if (skip) {
       skip("skipping whole data test case")
     }
-    
+
     testdata <- file.path("..", "testdata")
 
     filenames <- lapply(files, function(x) {
       file.path(testdata, "input", x)
     })
 
-    # CRAN limits the number of cores available to packages to 2
-    # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
-    chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
-
-    if (nzchar(chk) && chk == "TRUE") {
-      # use 2 cores in CRAN/Travis/AppVeyor
-      cluster <- 2L
-    } else {
-      # use all cores in devtools::test()
-      cluster <- parallel::detectCores()
-    }
+    cluster <- get_num_workers()
 
     if (!is(cluster, "cluster")) {
       cluster <- parallel::makeCluster(cluster)
@@ -30,23 +20,23 @@ patrick::with_parameters_test_that(
     }
 
     actual <- extract_features(
-        cluster = cluster,
-        filenames,
-        min_presence = min_presence,
-        min_elution_length = min_elution_length,
-        mz_tol = mz_tol,
-        baseline_correct = 0,
-        baseline_correct_noise_percentile = 0.05,
-        intensity_weighted = intensity_weighted,
-        min_bandwidth = NA,
-        max_bandwidth = NA,
-        sd_cut = sd_cut,
-        sigma_ratio_lim = sigma_ratio_lim,
-        shape_model = "bi-Gaussian",
-        peak_estim_method = "moment",
-        component_eliminate = 0.01,
-        moment_power = 1,
-        BIC_factor = 2.0
+      cluster = cluster,
+      filenames,
+      min_presence = min_presence,
+      min_elution_length = min_elution_length,
+      mz_tol = mz_tol,
+      baseline_correct = 0,
+      baseline_correct_noise_percentile = 0.05,
+      intensity_weighted = intensity_weighted,
+      min_bandwidth = NA,
+      max_bandwidth = NA,
+      sd_cut = sd_cut,
+      sigma_ratio_lim = sigma_ratio_lim,
+      shape_model = "bi-Gaussian",
+      peak_estim_method = "moment",
+      component_eliminate = 0.01,
+      moment_power = 1,
+      BIC_factor = 2.0
     )
     expected_filenames <- lapply(expected_files, function(x) {
       file.path(testdata, "extracted", x)

--- a/tests/testthat/test-two-step-hybrid.R
+++ b/tests/testthat/test-two-step-hybrid.R
@@ -18,20 +18,12 @@ test_that("basic two-step hybrid test", {
   expected_final_features <- readRDS("../testdata/final_ftrs.Rda")
   known_table <- arrow::read_parquet("../testdata/known_table.parquet")
 
-  chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
-
-  if (nzchar(chk) && chk == "TRUE") {
-    num_workers <- 2L
-  } else {
-    num_workers <- parallel::detectCores()
-  }
-
   result <- two.step.hybrid(
     filenames = test_names,
     metadata = metadata,
     work_dir = tempdir,
     known.table = known_table,
-    cluster = num_workers
+    cluster = get_num_workers()
   )
   final_features <- result$final_features
 

--- a/tests/testthat/test-unsupervised.R
+++ b/tests/testthat/test-unsupervised.R
@@ -1,23 +1,13 @@
 test_that("basic unsupervised test", {
-  test_files <- c('../testdata/input/mbr_test0.mzml',
-                  '../testdata/input/mbr_test1.mzml',
-                  '../testdata/input/mbr_test2.mzml')
-  
-  expected <- arrow::read_parquet('../testdata/unsupervised_recovered_feature_sample_table.parquet')
-  
-  # CRAN limits the number of cores available to packages to 2
-  # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
-  chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
-  
-  if (nzchar(chk) && chk == "TRUE") {
-    # use 2 cores in CRAN/Travis/AppVeyor
-    num_workers <- 2L
-  } else {
-    # use all cores in devtools::test()
-    num_workers <- parallel::detectCores()
-  }
-  
-  result <- unsupervised(test_files, cluster = num_workers)
+  test_files <- c(
+    "../testdata/input/mbr_test0.mzml",
+    "../testdata/input/mbr_test1.mzml",
+    "../testdata/input/mbr_test2.mzml"
+  )
+
+  expected <- arrow::read_parquet("../testdata/unsupervised_recovered_feature_sample_table.parquet")
+
+  result <- unsupervised(test_files, cluster = get_num_workers())
 
   expect_equal(result$recovered_feature_sample_table, expected)
 })


### PR DESCRIPTION
This PR includes the following:

- used get_num_workers in all test cases #135
- fixed extract_features and unsupervised benchmarking test