### PR TITLE
Use proper sample IDs inside feature tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactored `find.tol.time.R` [#91](https://github.com/RECETOX/recetox-aplcms/pull/91)
 - refactored `find.turn.point.R` [#91](https://github.com/RECETOX/recetox-aplcms/pull/91)
 - refactored `proc.cdf.R` and `adaptive.bin.R` [#137](https://github.com/RECETOX/recetox-aplcms/pull/137)
+- use proper sample IDs inside feature tables [#153](https://github.com/RECETOX/recetox-aplcms/pull/153)
 ### Removed
 
 ## [0.9.4] - 2022-05-10

--- a/R/adjust.time.R
+++ b/R/adjust.time.R
@@ -30,10 +30,10 @@ compute_template_adjusted_rt <- function(combined, sel, j) {
   # now the first column is the template retention time.
   # the second column is the to-be-adjusted retention time
 
-  cat(c("sample", j, "using", nrow(all_features), ", "))
-  if (j %% 3 == 0) {
-    cat("\n")
-  }
+  # cat(c("sample", j, "using", nrow(all_features), ", "))
+  # if (j %% 3 == 0) {
+  #   cat("\n")
+  # }
 
   all_features <- all_features[order(all_features[, 2]), ]
   return(all_features)
@@ -77,10 +77,11 @@ fill_missing_values <- function(orig.feature, this.feature) {
 
 compute_template <- function(extracted_features) {
   num.ftrs <- sapply(extracted_features, nrow)
-  template <- which.max(num.ftrs)
+  template_id <- which.max(num.ftrs)
+  template <- extracted_features[[template_id]]$sample_id[1]
   message(paste("the template is sample", template))
 
-  candi <- tibble::as_tibble(extracted_features[[template]]) |> dplyr::select(c(mz, rt))
+  candi <- tibble::as_tibble(extracted_features[[template_id]]) |> dplyr::select(c(mz, rt))
   template_features <- dplyr::bind_cols(candi, sample_id = rep(template, nrow(candi)))
   return(tibble::as_tibble(template_features))
 }

--- a/R/adjust.time.R
+++ b/R/adjust.time.R
@@ -29,12 +29,7 @@ compute_template_adjusted_rt <- function(combined, sel, j) {
 
   # now the first column is the template retention time.
   # the second column is the to-be-adjusted retention time
-
-  # cat(c("sample", j, "using", nrow(all_features), ", "))
-  # if (j %% 3 == 0) {
-  #   cat("\n")
-  # }
-
+  
   all_features <- all_features[order(all_features[, 2]), ]
   return(all_features)
 }

--- a/R/compute_clusters.R
+++ b/R/compute_clusters.R
@@ -12,7 +12,7 @@
 #' @param mz_max_diff float Maximum difference between featuure mz values to belong to the same cluster.
 #' @param rt_tol_relative float Relative retention time tolerance to use for grouping features.
 #' @param do.plot bool Plot graphics or not.
-#' @param sample_names list Given list of sample names.
+#' @param sample_names list List of sample names.
 #' @return Returns a list with following items:
 #' \itemize{
 #'   \item feature_tables - list - Feature tables with added columns [sample_id, cluster].

--- a/R/compute_clusters.R
+++ b/R/compute_clusters.R
@@ -18,15 +18,16 @@
 #'   \item rt_tol_relative - float - Newly determined relative rt tolerance.
 #'   \item mz_tol_relative - float - Newly determined relative mz tolerance.
 #'}
-compute_clusters <- function(feature_tables,
+compute_clusters <- function(sample_names,
+                             feature_tables,
                              mz_tol_relative,
                              mz_tol_absolute,
                              mz_max_diff,
                              rt_tol_relative,
                              do.plot = FALSE) {
   number_of_samples <- length(feature_tables)
-  all <- concatenate_feature_tables(feature_tables)
-
+  all <- concatenate_feature_tables(sample_names, feature_tables)
+  
   if (is.na(mz_tol_relative)) {
     mz_tol_relative <- find.tol(
       all$mz,

--- a/R/compute_clusters.R
+++ b/R/compute_clusters.R
@@ -18,15 +18,15 @@
 #'   \item rt_tol_relative - float - Newly determined relative rt tolerance.
 #'   \item mz_tol_relative - float - Newly determined relative mz tolerance.
 #'}
-compute_clusters <- function(sample_names,
-                             feature_tables,
+compute_clusters <- function(feature_tables,
                              mz_tol_relative,
                              mz_tol_absolute,
                              mz_max_diff,
                              rt_tol_relative,
-                             do.plot = FALSE) {
+                             do.plot = FALSE,
+                             sample_names = NA) {
   number_of_samples <- length(feature_tables)
-  all <- concatenate_feature_tables(sample_names, feature_tables)
+  all <- concatenate_feature_tables(feature_tables, sample_names)
   
   if (is.na(mz_tol_relative)) {
     mz_tol_relative <- find.tol(

--- a/R/compute_clusters.R
+++ b/R/compute_clusters.R
@@ -12,6 +12,7 @@
 #' @param mz_max_diff float Maximum difference between featuure mz values to belong to the same cluster.
 #' @param rt_tol_relative float Relative retention time tolerance to use for grouping features.
 #' @param do.plot bool Plot graphics or not.
+#' @param sample_names list Given list of sample names.
 #' @return Returns a list with following items:
 #' \itemize{
 #'   \item feature_tables - list - Feature tables with added columns [sample_id, cluster].

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -182,13 +182,13 @@ create_aligned_feature_table <- function(all_table,
 #' data(extracted)
 #' feature.align(extracted, mz_max_diff = 10 * 1e-05, do.plot = FALSE)
 feature.align <- function(features,
-                          sample_names,
                           min_occurrence = 2,
                           mz_tol_relative = NA,
                           rt_tol_relative = NA,
                           mz_max_diff = 1e-4,
                           mz_tol_absolute = 0.01,
-                          do.plot = TRUE) {
+                          do.plot = TRUE,
+                          sample_names = NA) {
     if (do.plot) {
         par(mfrow = c(3, 2))
         draw_plot(label = "Feature alignment", cex = 2)
@@ -198,12 +198,13 @@ feature.align <- function(features,
     number_of_samples <- length(features)
     if (number_of_samples > 1) {
         res <- compute_clusters(
-            sample_names,
             features,
             mz_tol_relative,
             mz_tol_absolute,
             mz_max_diff,
-            rt_tol_relative
+            rt_tol_relative,
+            do.plot,
+            sample_names
         )
 
         all_table <- dplyr::bind_rows(res$feature_tables)

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -170,7 +170,7 @@ create_aligned_feature_table <- function(all_table,
 #'  when the m/z range is wide. This parameter limits the tolerance in absolute terms. It mostly
 #'  influences feature matching in higher m/z range.
 #' @param do.plot Indicates whether plot should be drawn.
-#' @param sample_names list Given list of sample names.
+#' @param sample_names list List of sample names.
 #' @return Returns a list object with the following objects in it:
 #' \itemize{
 #'   \item aligned.ftrs - A matrix, with columns of m/z values, elution times, signal strengths in each spectrum.

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -181,7 +181,7 @@ create_aligned_feature_table <- function(all_table,
 #' @export
 #' @examples
 #' data(extracted)
-#' feature.align(extracted, mz_max_diff = 10 * 1e-05, do.plot = FALSE)
+#' feature.align(extracted, mz_max_diff = 10 * 1e-05, do.plot = FALSE, sample_names = c("s1", "s2", "s3"))
 feature.align <- function(features,
                           min_occurrence = 2,
                           mz_tol_relative = NA,

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -170,6 +170,7 @@ create_aligned_feature_table <- function(all_table,
 #'  when the m/z range is wide. This parameter limits the tolerance in absolute terms. It mostly
 #'  influences feature matching in higher m/z range.
 #' @param do.plot Indicates whether plot should be drawn.
+#' @param sample_names list Given list of sample names.
 #' @return Returns a list object with the following objects in it:
 #' \itemize{
 #'   \item aligned.ftrs - A matrix, with columns of m/z values, elution times, signal strengths in each spectrum.

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -16,13 +16,14 @@ add_row <- function(df, data, i, column_names) {
 }
 
 
-create_output <- function(sample_grouped, number_of_samples) {
+create_output <- function(sample_grouped, sample_names) {
+    number_of_samples <- length(sample_names)
     intensity_row <- rep(0, number_of_samples)
     rt_row <- rep(0, number_of_samples)
     sample_presence <- rep(0, number_of_samples)
     
     for (i in seq_along(intensity_row)) {
-        filtered <- filter(sample_grouped, sample_id == i)
+        filtered <- filter(sample_grouped, sample_id == sample_names[i])
         if (nrow(filtered) != 0) {
             sample_presence[i] <- 1
             intensity_row[i] <- sum(filtered$area)
@@ -68,23 +69,23 @@ filter_based_on_density <- function(sample, turns, index, i) {
 }
 
 
-select_rt <- function(sample, rt_tol_relative, min_occurrence, number_of_samples) {
+select_rt <- function(sample, rt_tol_relative, min_occurrence, sample_names) {
     turns <- find_optima(sample$rt, bandwidth = rt_tol_relative / 1.414)
     for (i in seq_along(turns$peaks)) {
         sample_grouped <- filter_based_on_density(sample, turns, 2, i)
         if (validate_contents(sample_grouped, min_occurrence)) {
-            return(create_output(sample_grouped, number_of_samples))
+            return(create_output(sample_grouped, sample_names))
         }
     }
 }
 
 
-select_mz <- function(sample, mz_tol_relative, rt_tol_relative, min_occurrence, number_of_samples) {
+select_mz <- function(sample, mz_tol_relative, rt_tol_relative, min_occurrence, sample_names) {
     turns <- find_optima(sample$mz, bandwidth = mz_tol_relative * median(sample$mz))
     for (i in seq_along(turns$peaks)) {
         sample_grouped <- filter_based_on_density(sample, turns, 1, i)
         if (validate_contents(sample_grouped, min_occurrence)) {
-            return(select_rt(sample_grouped, rt_tol_relative, min_occurrence, number_of_samples))
+            return(select_rt(sample_grouped, rt_tol_relative, min_occurrence, sample_names))
         }
     }
 }
@@ -96,18 +97,18 @@ create_rows <- function(features,
                         mz_tol_relative,
                         rt_tol_relative,
                         min_occurrence,
-                        number_of_samples) {
+                        sample_names) {
     if (i %% 100 == 0) {
         gc()
     } # call Garbage Collection for performance improvement?
-
+    
     sample <- dplyr::filter(features, cluster == sel.labels[i])
     if (nrow(sample) > 1) {
         if (validate_contents(sample, min_occurrence)) {
-            return(select_mz(sample, mz_tol_relative, rt_tol_relative, min_occurrence, number_of_samples))
+            return(select_mz(sample, mz_tol_relative, rt_tol_relative, min_occurrence, sample_names))
         }
     } else if (min_occurrence == 1) {
-        return(create_output(sample_grouped, number_of_samples))
+        return(create_output(sample_grouped, sample_names))
     }
     return(NULL)
 }
@@ -115,13 +116,14 @@ create_rows <- function(features,
 
 create_aligned_feature_table <- function(all_table,
                                          min_occurrence,
-                                         number_of_samples,
+                                         sample_names,
                                          rt_tol_relative,
                                          mz_tol_relative) {
     
-    metadata_colnames <- c("id", "mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "npeaks", paste0("sample_", 1:number_of_samples))
-    intensity_colnames <- c("id", paste0("sample_", 1:number_of_samples, "_intensity"))
-    rt_colnames <- c("id", paste0("sample_", 1:number_of_samples, "_rt"))
+    number_of_samples <- length(sample_names)
+    metadata_colnames <- c("id", "mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "npeaks", sample_names)
+    intensity_colnames <- c("id", paste0(sample_names, "_intensity"))
+    rt_colnames <- c("id", paste0(sample_names, "_rt"))
     
     aligned_features <- create_empty_tibble(number_of_samples, metadata_colnames, intensity_colnames, rt_colnames)
     
@@ -139,7 +141,7 @@ create_aligned_feature_table <- function(all_table,
             mz_tol_relative,
             rt_tol_relative,
             min_occurrence,
-            number_of_samples
+            sample_names
         )
         
         if (!is.null(rows)) {
@@ -180,6 +182,7 @@ create_aligned_feature_table <- function(all_table,
 #' data(extracted)
 #' feature.align(extracted, mz_max_diff = 10 * 1e-05, do.plot = FALSE)
 feature.align <- function(features,
+                          sample_names,
                           min_occurrence = 2,
                           mz_tol_relative = NA,
                           rt_tol_relative = NA,
@@ -191,11 +194,11 @@ feature.align <- function(features,
         draw_plot(label = "Feature alignment", cex = 2)
         draw_plot()
     }
-
-
+    
     number_of_samples <- length(features)
     if (number_of_samples > 1) {
         res <- compute_clusters(
+            sample_names,
             features,
             mz_tol_relative,
             mz_tol_absolute,
@@ -208,7 +211,7 @@ feature.align <- function(features,
         aligned_features <- create_aligned_feature_table(
             all_table,
             min_occurrence,
-            number_of_samples,
+            sample_names,
             res$rt_tol_relative,
             res$mz_tol_relative
         )

--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -318,7 +318,7 @@ hybrid <- function(
   aligned <- create_aligned_feature_table(
       dplyr::bind_rows(adjusted_clusters$feature_tables),
       min_exp,
-      number_of_samples,
+      sample_names,
       adjusted_clusters$rt_tol_relative,
       adjusted_clusters$mz_tol_relative
   )
@@ -392,7 +392,7 @@ hybrid <- function(
   recovered_aligned <- create_aligned_feature_table(
       dplyr::bind_rows(adjusted_clusters$feature_tables),
       min_exp,
-      number_of_samples,
+      sample_names,
       adjusted_clusters$rt_tol_relative,
       adjusted_clusters$mz_tol_relative
   )

--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -290,7 +290,8 @@ hybrid <- function(
     mz_tol_relative = align_mz_tol,
     mz_tol_absolute = max_align_mz_diff,
     mz_max_diff = 10 * mz_tol,
-    rt_tol_relative = align_rt_tol
+    rt_tol_relative = align_rt_tol,
+    sample_names = sample_names
   )
 
   message("**** computing template ****")

--- a/R/recover.weaker.R
+++ b/R/recover.weaker.R
@@ -669,7 +669,6 @@ recover.weaker <- function(filename,
                            bandwidth = .5,
                            recover.min.count = 3,
                            intensity.weighted = FALSE) {
-
   # load raw data
   data_table <- load_file(filename) |> dplyr::arrange_at("mz")
   times <- sort(unique(data_table$rt))
@@ -778,7 +777,7 @@ recover.weaker <- function(filename,
           mz = this.rec$mz[this.sel],
           rt = this.rec$rt[this.sel] + this.time.adjust,
           area = this.rec$intensities[this.sel],
-          sample_id = grep(sample_name, colnames(metadata_table)) - 8 # offset for other columns `mz`, `rt` etc
+          sample_id = sample_name
         )
       }
     }

--- a/R/semi.sup.R
+++ b/R/semi.sup.R
@@ -105,7 +105,8 @@ semi.sup <- function(
     match.tol.ppm=NA,
     new.feature.min.count=2,
     recover.min.count=3,
-    intensity.weighted=FALSE)
+    intensity.weighted=FALSE,
+    sample_names = NA)
 {
     setwd(folder)
     files<-files[order(files)]
@@ -243,7 +244,8 @@ semi.sup <- function(
               mz_tol_relative = align.mz.tol,
               rt_tol_relative = align.rt.tol,
               mz_max_diff = 10 * mz.tol,
-              mz_tol_absolute = max.align.mz.diff
+              mz_tol_absolute = max.align.mz.diff,
+              sample_names = sample_names
             )
         )
         
@@ -456,7 +458,8 @@ semi.sup <- function(
               mz_tol_relative = align.mz.tol,
               rt_tol_relative = align.rt.tol,
               mz_max_diff = 10 * mz.tol,
-              mz_tol_absolute = max.align.mz.diff
+              mz_tol_absolute = max.align.mz.diff,
+              sample_names = sample_names
             )
         )
         

--- a/R/two.step.hybrid.R
+++ b/R/two.step.hybrid.R
@@ -363,6 +363,8 @@ two.step.hybrid <- function(filenames,
   batches_idx <- unique(metadata$batch)
   batchwise <- new("list")
   message("* processing ", length(batches_idx), " batches separately")
+  
+  sample_names <- get_sample_name(filenames)
 
   for (batch.i in batches_idx) {
     files_batch <- dplyr::filter(filenames_batchwise, batch == batch.i)$filename
@@ -391,7 +393,8 @@ two.step.hybrid <- function(filenames,
       use.observed.range = use.observed.range,
       shape.model = shape.model,
       new.feature.min.count = new.feature.min.count,
-      recover.min.count = recover.min.count
+      recover.min.count = recover.min.count,
+      sample_names = sample_names
     )
 
     features$final.ftrs <- features$final.ftrs[order(features$final.ftrs[, 1], features$final.ftrs[, 2]), ]

--- a/R/unsupervised.R
+++ b/R/unsupervised.R
@@ -238,12 +238,12 @@ unsupervised <- function(
 
   message("**** computing clusters ****")
   extracted_clusters <- compute_clusters(
-    sample_names = sample_names,
     feature_tables = extracted,
     mz_tol_relative = align_mz_tol,
     mz_tol_absolute = max_align_mz_diff,
     mz_max_diff = 10 * mz_tol,
-    rt_tol_relative = align_rt_tol
+    rt_tol_relative = align_rt_tol,
+    sample_names = sample_names
   )
 
   message("**** computing template ****")
@@ -260,7 +260,6 @@ unsupervised <- function(
 
   message("**** computing clusters ****")
   adjusted_clusters <- compute_clusters(
-    sample_names = sample_names,
     feature_tables = corrected,
     mz_tol_relative = extracted_clusters$mz_tol_relative,
     mz_tol_absolute = extracted_clusters$rt_tol_relative,

--- a/R/unsupervised.R
+++ b/R/unsupervised.R
@@ -58,6 +58,7 @@ sort_samples_by_acquisition_number <- function (filenames) {
 }
 
 align_features <- function(sample_names, ...) {
+  # if this will be used in Galaxy wrapper, needs to be fixed (pass also sample_names)
   aligned <- feature.align(...)
 
   list(

--- a/R/unsupervised.R
+++ b/R/unsupervised.R
@@ -238,6 +238,7 @@ unsupervised <- function(
 
   message("**** computing clusters ****")
   extracted_clusters <- compute_clusters(
+    sample_names = sample_names,
     feature_tables = extracted,
     mz_tol_relative = align_mz_tol,
     mz_tol_absolute = max_align_mz_diff,
@@ -259,6 +260,7 @@ unsupervised <- function(
 
   message("**** computing clusters ****")
   adjusted_clusters <- compute_clusters(
+    sample_names = sample_names,
     feature_tables = corrected,
     mz_tol_relative = extracted_clusters$mz_tol_relative,
     mz_tol_absolute = extracted_clusters$rt_tol_relative,

--- a/R/unsupervised.R
+++ b/R/unsupervised.R
@@ -272,7 +272,7 @@ unsupervised <- function(
   aligned <- create_aligned_feature_table(
       dplyr::bind_rows(adjusted_clusters$feature_tables),
       min_exp,
-      number_of_samples,
+      sample_names,
       adjusted_clusters$rt_tol_relative,
       adjusted_clusters$mz_tol_relative
   )
@@ -316,7 +316,7 @@ unsupervised <- function(
   recovered_aligned <- create_aligned_feature_table(
       dplyr::bind_rows(recovered_clusters$feature_tables),
       min_exp,
-      number_of_samples,
+      sample_names,
       recovered_clusters$rt_tol_relative,
       recovered_clusters$mz_tol_relative
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,10 +5,10 @@ NULL
 #' Concatenate multiple feature lists and add the sample id (origin of feature) as additional column.
 #' 
 #' @param features list List of tibbles containing extracted feature tables.
-concatenate_feature_tables <- function(features) {
+concatenate_feature_tables <- function(sample_names, features) {
   for (i in seq_along(features)) {
     if(!("sample_id" %in% colnames(features[[i]]))) {
-      features[[i]] <- tibble::add_column(features[[i]], sample_id = i)
+      features[[i]] <- tibble::add_column(features[[i]], sample_id = sample_names[i])
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,7 @@ NULL
 #' 
 #' @param features list List of tibbles containing extracted feature tables.
 concatenate_feature_tables <- function(features, sample_names) {
-    if(!is.na(sample_names)) {
+    if(!all(is.na(sample_names))) {
         for (i in seq_along(features)) {
             if(!("sample_id" %in% colnames(features[[i]]))) {
                 features[[i]] <- tibble::add_column(features[[i]], sample_id = sample_names[i])

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,15 +5,17 @@ NULL
 #' Concatenate multiple feature lists and add the sample id (origin of feature) as additional column.
 #' 
 #' @param features list List of tibbles containing extracted feature tables.
-concatenate_feature_tables <- function(sample_names, features) {
-  for (i in seq_along(features)) {
-    if(!("sample_id" %in% colnames(features[[i]]))) {
-      features[[i]] <- tibble::add_column(features[[i]], sample_id = sample_names[i])
+concatenate_feature_tables <- function(features, sample_names) {
+    if(!is.na(sample_names)) {
+        for (i in seq_along(features)) {
+            if(!("sample_id" %in% colnames(features[[i]]))) {
+                features[[i]] <- tibble::add_column(features[[i]], sample_id = sample_names[i])
+            }
+        }
     }
-  }
-
-  merged <- dplyr::bind_rows(features)
-  return(merged)
+    
+    merged <- dplyr::bind_rows(features)
+    return(merged)
 }
 
 #' @export
@@ -23,106 +25,106 @@ extract_pattern_colnames <- function(dataframe, pattern) {
 }
 
 as_wide_aligned_table <- function(aligned) {
-  mz_scale_table <- aligned$rt_crosstab[, c("mz", "rt", "mz_min", "mz_max")]
-  aligned <- as_feature_sample_table(
-    rt_crosstab = aligned$rt_crosstab,
-    int_crosstab = aligned$int_crosstab
-  )
-  aligned <- long_to_wide_feature_table(aligned)
-  aligned <- dplyr::inner_join(aligned, mz_scale_table, by = c("mz", "rt"))
-  return(aligned)
+    mz_scale_table <- aligned$rt_crosstab[, c("mz", "rt", "mz_min", "mz_max")]
+    aligned <- as_feature_sample_table(
+        rt_crosstab = aligned$rt_crosstab,
+        int_crosstab = aligned$int_crosstab
+    )
+    aligned <- long_to_wide_feature_table(aligned)
+    aligned <- dplyr::inner_join(aligned, mz_scale_table, by = c("mz", "rt"))
+    return(aligned)
 }
 
 pivot_feature_values <- function(feature_table, variable) {
-  extended_variable <- paste0("sample_", variable)
-  values <- dplyr::select(feature_table, mz, rt, sample, !!sym(extended_variable))
-  values <- tidyr::pivot_wider(values, names_from = sample, values_from = !!sym(extended_variable))
-  variable_colnames <- colnames(values)[3:ncol(values)]
-  variable_colnames <- paste0(variable_colnames, "_", variable)
-  colnames(values)[3:ncol(values)] <- variable_colnames
-  return(values)
+    extended_variable <- paste0("sample_", variable)
+    values <- dplyr::select(feature_table, mz, rt, sample, !!sym(extended_variable))
+    values <- tidyr::pivot_wider(values, names_from = sample, values_from = !!sym(extended_variable))
+    variable_colnames <- colnames(values)[3:ncol(values)]
+    variable_colnames <- paste0(variable_colnames, "_", variable)
+    colnames(values)[3:ncol(values)] <- variable_colnames
+    return(values)
 }
 
 long_to_wide_feature_table <- function(feature_table) {
-  sample_rts <- pivot_feature_values(feature_table, "rt")
-  sample_intensities <- pivot_feature_values(feature_table, "intensity")
-  feature_table <- dplyr::select(feature_table, mz, rt) %>%
-    dplyr::distinct(mz, rt) %>%
-    dplyr::inner_join(sample_rts, by = c("mz", "rt")) %>%
-    dplyr::inner_join(sample_intensities, by = c("mz", "rt"))
+    sample_rts <- pivot_feature_values(feature_table, "rt")
+    sample_intensities <- pivot_feature_values(feature_table, "intensity")
+    feature_table <- dplyr::select(feature_table, mz, rt) %>%
+        dplyr::distinct(mz, rt) %>%
+        dplyr::inner_join(sample_rts, by = c("mz", "rt")) %>%
+        dplyr::inner_join(sample_intensities, by = c("mz", "rt"))
 }
 
 wide_to_long_feature_table <- function(wide_table, sample_names) {
-  wide_table <- tibble::rowid_to_column(wide_table, "feature")
-
-  long_rt <- tidyr::gather(wide_table, sample, sample_rt, contains("_rt"), factor_key=FALSE) %>%
-    dplyr::select(-contains("_intensity")) %>%
-    mutate(sample = stringr::str_remove_all(sample, "_rt"))
-  long_int <- tidyr::gather(wide_table, sample, sample_intensity, contains("_intensity"), factor_key=FALSE) %>%
-    dplyr::select(-contains("_rt")) %>%
-    mutate(sample = stringr::str_remove_all(sample, "_intensity"))
-  
-  long_features <- dplyr::full_join(long_rt, long_int, by = c("feature", "mz", "rt", "mz_min", "mz_max", "sample"))
-  
-  return(long_features)
+    wide_table <- tibble::rowid_to_column(wide_table, "feature")
+    
+    long_rt <- tidyr::gather(wide_table, sample, sample_rt, contains("_rt"), factor_key=FALSE) %>%
+        dplyr::select(-contains("_intensity")) %>%
+        mutate(sample = stringr::str_remove_all(sample, "_rt"))
+    long_int <- tidyr::gather(wide_table, sample, sample_intensity, contains("_intensity"), factor_key=FALSE) %>%
+        dplyr::select(-contains("_rt")) %>%
+        mutate(sample = stringr::str_remove_all(sample, "_intensity"))
+    
+    long_features <- dplyr::full_join(long_rt, long_int, by = c("feature", "mz", "rt", "mz_min", "mz_max", "sample"))
+    
+    return(long_features)
 }
 
 load_aligned_features <- function(metadata_file, intensities_file, rt_file, tol_file) {
-  metadata <- arrow::read_parquet(metadata_file)
-  intensities <- arrow::read_parquet(intensities_file)
-  rt <- arrow::read_parquet(rt_file)
-  tolerances <- arrow::read_parquet(tol_file)
-  
-  result <- list()
-  result$metadata <- as_tibble(metadata)
-  result$intensity <- as_tibble(intensities)
-  result$rt <- as_tibble(rt)
-  result$mz_tol_relative <- tolerances$mz_tolerance
-  result$rt_tol_relative <- tolerances$rt_tolerance
-  return(result)
+    metadata <- arrow::read_parquet(metadata_file)
+    intensities <- arrow::read_parquet(intensities_file)
+    rt <- arrow::read_parquet(rt_file)
+    tolerances <- arrow::read_parquet(tol_file)
+    
+    result <- list()
+    result$metadata <- as_tibble(metadata)
+    result$intensity <- as_tibble(intensities)
+    result$rt <- as_tibble(rt)
+    result$mz_tol_relative <- tolerances$mz_tolerance
+    result$rt_tol_relative <- tolerances$rt_tolerance
+    return(result)
 }
 
 create_feature_sample_table <- function(features) {
-  table <- as_feature_sample_table(
-    rt_crosstab = features$rt,
-    int_crosstab = features$intensity
-  )
-  return(table)
+    table <- as_feature_sample_table(
+        rt_crosstab = features$rt,
+        int_crosstab = features$intensity
+    )
+    return(table)
 }
 
 #' @export
 span <- function(x) {
-  diff(range(x, na.rm = TRUE))
+    diff(range(x, na.rm = TRUE))
 }
 
 #' @description
 #' Compute standard deviation of m/z values groupwise
 #' @export
 compute_mz_sd <- function(feature_groups) {
-  mz_sd <- c()
-  for (i in seq_along(feature_groups)) {
-    group <- feature_groups[[i]]
-
-    if (nrow(group > 1)) {
-      group_sd <- sd(group[, "mz"])
-      mz_sd <- append(mz_sd, group_sd)
+    mz_sd <- c()
+    for (i in seq_along(feature_groups)) {
+        group <- feature_groups[[i]]
+        
+        if (nrow(group > 1)) {
+            group_sd <- sd(group[, "mz"])
+            mz_sd <- append(mz_sd, group_sd)
+        }
     }
-  }
-  return(mz_sd)
+    return(mz_sd)
 }
 
 #' @export
 get_num_workers <- function() {
-  # CRAN limits the number of cores available to packages to 2
-  # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
-  chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
-  
-  if (nzchar(chk) && chk == "TRUE") {
-    # use 2 cores in CRAN/Travis/AppVeyor
-    num_workers <- 2L
-  } else {
-    # use all cores in devtools::test()
-    num_workers <- parallel::detectCores()
-  }
-  return(num_workers)
+    # CRAN limits the number of cores available to packages to 2
+    # source https://stackoverflow.com/questions/50571325/r-cran-check-fail-when-using-parallel-functions#50571533
+    chk <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
+    
+    if (nzchar(chk) && chk == "TRUE") {
+        # use 2 cores in CRAN/Travis/AppVeyor
+        num_workers <- 2L
+    } else {
+        # use all cores in devtools::test()
+        num_workers <- parallel::detectCores()
+    }
+    return(num_workers)
 }

--- a/man/feature.align.Rd
+++ b/man/feature.align.Rd
@@ -11,7 +11,8 @@ feature.align(
   rt_tol_relative = NA,
   mz_max_diff = 1e-04,
   mz_tol_absolute = 0.01,
-  do.plot = TRUE
+  do.plot = TRUE,
+  sample_names = NA
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ when the m/z range is wide. This parameter limits the tolerance in absolute term
 influences feature matching in higher m/z range.}
 
 \item{do.plot}{Indicates whether plot should be drawn.}
+
+\item{sample_names}{Given list of sample names.}
 }
 \value{
 Returns a list object with the following objects in it:

--- a/tests/testthat/test-compute_clusters.R
+++ b/tests/testthat/test-compute_clusters.R
@@ -9,6 +9,7 @@ patrick::with_parameters_test_that(
     })
 
     actual <- compute_clusters(
+      sample_names = files,
       feature_tables = extracted,
       mz_tol_relative = NA,
       rt_tol_relative = NA,

--- a/tests/testthat/test-compute_clusters.R
+++ b/tests/testthat/test-compute_clusters.R
@@ -9,12 +9,12 @@ patrick::with_parameters_test_that(
     })
 
     actual <- compute_clusters(
-      sample_names = files,
       feature_tables = extracted,
       mz_tol_relative = NA,
       rt_tol_relative = NA,
       mz_max_diff = mz_max_diff,
-      mz_tol_absolute = mz_tol_absolute
+      mz_tol_absolute = mz_tol_absolute,
+      sample_names = files
     )
 
     expected <- lapply(files, function(x) {

--- a/tests/testthat/test-feature-align.R
+++ b/tests/testthat/test-feature-align.R
@@ -19,6 +19,7 @@ patrick::with_parameters_test_that(
 
     aligned_actual <- feature.align(
       features = corrected_features,
+      sample_names = files,
       min_occurrence = min_occurrence,
       mz_tol_relative = mz_tol_relative,
       rt_tol_relative = rt_tol_relative,

--- a/tests/testthat/test-feature-align.R
+++ b/tests/testthat/test-feature-align.R
@@ -67,7 +67,7 @@ patrick::with_parameters_test_that(
     aligned_actual <- create_aligned_feature_table(
         dplyr::bind_rows(corrected_features),
         min_occurrence,
-        length(files),
+        files,
         rt_tol_relative,
         mz_tol_relative
     )

--- a/tests/testthat/test-feature-align.R
+++ b/tests/testthat/test-feature-align.R
@@ -19,13 +19,13 @@ patrick::with_parameters_test_that(
 
     aligned_actual <- feature.align(
       features = corrected_features,
-      sample_names = files,
       min_occurrence = min_occurrence,
       mz_tol_relative = mz_tol_relative,
       rt_tol_relative = rt_tol_relative,
       mz_max_diff = 10 * mz_tol,
       mz_tol_absolute = mz_tol_absolute,
-      do.plot = do.plot
+      do.plot = do.plot,
+      sample_names = files
     )
 
     aligned_expected <- load_aligned_features(

--- a/tests/testthat/test-recover-weaker.R
+++ b/tests/testthat/test-recover-weaker.R
@@ -28,7 +28,7 @@ patrick::with_parameters_test_that(
     recovered <- lapply(seq_along(ms_files), function(i) {
       recover.weaker(
         filename = ms_files[[i]],
-        sample_name = as.character(i),
+        sample_name = files[i],
         extracted_features = extracted[[i]],
         adjusted_features = adjusted[[i]],
         metadata_table = aligned$metadata,
@@ -65,7 +65,7 @@ patrick::with_parameters_test_that(
       xx <- file.path(testdata, "recovered", "recovered-corrected", paste0(x, ".parquet"))
       arrow::read_parquet(xx) |> dplyr::arrange_at(keys)
     })
-
+    
 
     # compare files
     for (i in seq_along(files)) {


### PR DESCRIPTION
All feature tables contained arbitrary (resp. based on input order) integer sample IDs. The original name of the sample was lost during the feature extraction process. This PR reintroduces them again and uses them to identify the sample across the computation.

Requires files update [here](https://gitlab.ics.muni.cz/umsa/umsa-files/-/merge_requests/23).