### PR TITLE
updated CI with codecov

### DIFF
--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -68,17 +68,10 @@ jobs:
         run: wget -P tests/testdata/template -i tests/remote-files/template.txt
       - name: Fetch unsupervised test data
         run: wget -P tests/testdata/unsupervised -i tests/remote-files/unsupervised.txt
-      - name: Activate conda environment
-        run: conda activate recetox-aplcms
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::covr
-          needs: coverage
 
       - name: Test coverage
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          conda activate recetox-aplcms
+          devtools::install_github("r-lib/covr")
+          covr::codecov(quiet = FALSE)
         shell: Rscript {0}

--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -19,6 +19,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     defaults:
       run:
         shell: bash -l {0}
@@ -66,7 +68,15 @@ jobs:
         run: wget -P tests/testdata/template -i tests/remote-files/template.txt
       - name: Fetch unsupervised test data
         run: wget -P tests/testdata/unsupervised -i tests/remote-files/unsupervised.txt
-      - name: Run devtools::check()
-        run: |
-          conda activate recetox-aplcms
-          Rscript -e "devtools::check('.', error_on = 'error')"
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr
+          needs: coverage
+
+      - name: Test coverage
+        run: covr::codecov(quiet = FALSE)
+        shell: Rscript {0}

--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -68,6 +68,8 @@ jobs:
         run: wget -P tests/testdata/template -i tests/remote-files/template.txt
       - name: Fetch unsupervised test data
         run: wget -P tests/testdata/unsupervised -i tests/remote-files/unsupervised.txt
+      - name: Activate conda environment
+        run: conda activate recetox-aplcms
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -72,6 +72,5 @@ jobs:
       - name: Test coverage
         run: |
           conda activate recetox-aplcms
-          devtools::install_github("r-lib/covr")
-          covr::codecov(quiet = FALSE)
-        shell: Rscript {0}
+          Rscript -e "devtools::install_github('r-lib/covr')"
+          Rscript -e "covr::codecov(quiet = FALSE)"

--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -72,5 +72,4 @@ jobs:
       - name: Test coverage
         run: |
           conda activate recetox-aplcms
-          Rscript -e "devtools::install_github('r-lib/covr')"
           Rscript -e "covr::codecov(quiet = FALSE)"

--- a/conda/environment-dev.yaml
+++ b/conda/environment-dev.yaml
@@ -36,4 +36,4 @@ dependencies:
   - radian
   - r-httpgd
   - r-microbenchmark
-
+  - r-covr


### PR DESCRIPTION
This PR removes the devtools::check and update it with covr::codecov test coverage in the CI.

TODO/Note: Configure [Codecov's GitHub app](https://github.com/apps/codecov) so Codecov can use the integration to post statuses and comments OR connect bot to the codecov account with repo permissions to post statuses and comments.

closes #28 closes #18