### PR TITLE
Use updated tolerances in workflows

### DIFF
--- a/R/hybrid.R
+++ b/R/hybrid.R
@@ -439,8 +439,8 @@ hybrid <- function(
       rt_table = merged$rt,
       intensity_table = merged$intensity,
       mz_tol = mz_tol,
-      mz_tol_relative = extracted_clusters$mz_tol_relative,
-      rt_tol_relative = extracted_clusters$rt_tol_relative,
+      mz_tol_relative = adjusted_clusters$mz_tol_relative,
+      rt_tol_relative = adjusted_clusters$rt_tol_relative,
       recover_mz_range = recover_mz_range,
       recover_rt_range = recover_rt_range,
       use_observed_range = use_observed_range,
@@ -524,8 +524,8 @@ hybrid <- function(
     corrected_features = corrected,
     aligned_feature_sample_table = aligned_feature_sample_table,
     recovered_feature_sample_table = recovered_feature_sample_table,
-    aligned_mz_tolerance = as.numeric(recovered_aligned$mz_tolerance),
-    aligned_rt_tolerance = as.numeric(recovered_aligned$rt_tolerance),
+    aligned_mz_tolerance = as.numeric(adjusted_clusters$mz_tolerance),
+    aligned_rt_tolerance = as.numeric(adjusted_clusters$rt_tolerance),
     updated_known_table = as.data.frame(augmented$known_table),
     features_known_table_pairing = as.data.frame(augmented$pairing)
   )

--- a/R/unsupervised.R
+++ b/R/unsupervised.R
@@ -219,8 +219,8 @@ unsupervised <- function(
       rt_table = aligned$rt,
       intensity_table = aligned$intensity,
       mz_tol = mz_tol,
-      mz_tol_relative = aligned$mz_tol_relative,
-      rt_tol_relative = aligned$rt_tol_relative,
+      mz_tol_relative = adjusted_clusters$mz_tol_relative,
+      rt_tol_relative = adjusted_clusters$rt_tol_relative,
       recover_mz_range = recover_mz_range,
       recover_rt_range = recover_rt_range,
       use_observed_range = use_observed_range,
@@ -271,7 +271,7 @@ unsupervised <- function(
     corrected_features = recovered$adjusted_features,
     aligned_feature_sample_table = aligned_feature_sample_table,
     recovered_feature_sample_table = recovered_feature_sample_table,
-    aligned_mz_tolerance = as.numeric(aligned$mz_tol_relative),
-    aligned_rt_tolerance = as.numeric(aligned$rt_tol_relative)
+    aligned_mz_tolerance = as.numeric(recovered_clusters$mz_tol_relative),
+    aligned_rt_tolerance = as.numeric(recovered_clusters$rt_tol_relative)
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,6 +22,7 @@ register_functions_to_cluster <- function(cluster) {
         'compute_breaks',
         'compute_breaks_3',
         'compute_boundaries',
+        'compute_rt_intervals_indices',
         'increment_counter',
         'rm.ridge',
         'compute_delta_rt',

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To use a docker development environment you need **Docker** installed on your ma
     ```shell
     $ apt install git && git config --global --add safe.directory /usr/src/recetox-aplcms
     ```
-- Enter a Conda environment by running `conda activate recetox-aplcms`
+- Enter a Conda environment by running `conda activate recetox-aplcms-dev`
 - Run `R` or `radian` to enter R terminal (we recommend `radian` due to its ease of use);
 - A good starting point would be fetching the test data as described above, running `devtools::test()` and waiting until all tests pass to ensure the environment is set correctly.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The development environment can be set up in two ways, either via **VSCode's dev
 To use a devcontainer you need VSCode with [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension and docker installed on your machine:
 - Clone your fork of the repository and open the folder in VSCode;
 - From VSCode's command palette run `Remote-Containers: Open Folder in Container`. VSCode may take a few minutes building a container;
-- After container is ready, open a **new** terminal and type `conda activate recetox-aplcms` to activate Conda environment;
+- After container is ready, open a **new** terminal and type `conda activate recetox-aplcms-dev` to activate Conda environment;
 - Run `R` or `radian` to enter R terminal (we recommend `radian` due to its ease of use);
 - A good starting point would be fetching the test data as described above, running `devtools::test()` and waiting until all tests pass to ensure the environment is set correctly.
 


### PR DESCRIPTION
This PR ensures that in the `unsupervised` and `hybrid` workflows, the updated tolerances are always used.

This also required change of [test files](https://gitlab.ics.muni.cz/umsa/umsa-files/-/merge_requests/27).

Close #176.