### PR TITLE
Remove sample name suffixes and peak picking corner case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [dev] - unreleased
+### Added
+### Changed
+- sample names in aligned tables no longer use _intensity and _rt suffixes [#212](https://github.com/RECETOX/recetox-aplcms/pull/212)
+### Removed
+- corner case in peak picking when an EIC was between 2 and 10 features [#212](https://github.com/RECETOX/recetox-aplcms/pull/212)
+
 ## [0.11.0] - 2023-05-09
 ### Added
  - implemented new clustering algorithm and included parallelism in unsupervised and hybrid [#201](https://github.com/RECETOX/recetox-aplcms/pull/201)

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -144,8 +144,8 @@ create_aligned_feature_table <- function(features_table,
 
     number_of_samples <- length(sample_names)
     metadata_colnames <- c("id", "mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "npeaks", sample_names)
-    intensity_colnames <- c("id", paste0(sample_names, "_intensity"))
-    rt_colnames <- c("id", paste0(sample_names, "_rt"))
+    intensity_colnames <- c("id", sample_names)
+    rt_colnames <- c("id", sample_names)
 
     aligned_features <- create_empty_tibble(number_of_samples, metadata_colnames, intensity_colnames, rt_colnames)
 

--- a/R/prof.to.features.R
+++ b/R/prof.to.features.R
@@ -933,19 +933,11 @@ prof.to.features <- function(profile,
     num_features <- nrow(feature_group)
     # The estimation procedure for a single peak
     # Defines the dataframe containing median_mz, median_rt, sd1, sd2, and area
-    if (dplyr::between(num_features, 2, 10)) {
-      # linear interpolation of  missing intensities and calculate the area for a single EIC
-      eic_area <- interpol.area(feature_group[, "rt"], feature_group[, "intensity"], base.curve[, "base.curve"], all_diff_mean_rts)
-      rt_peak_shape <- c(median(feature_group[, "mz"]), median(feature_group[, "rt"]), sd(feature_group[, "rt"]), sd(feature_group[, "rt"]), eic_area)
-      peak_parameters <- rbind(peak_parameters, rt_peak_shape)
-    }
     if (num_features < 2) {
       time_weights <- all_diff_mean_rts[which(base.curve[, "base.curve"] %in% feature_group[2])]
       rt_peak_shape <- c(feature_group[1], feature_group[2], NA, NA, feature_group[3] * time_weights)
       peak_parameters <- rbind(peak_parameters, rt_peak_shape)
-    }
-    # application of selected model and method  
-    if (num_features > 10) {
+    } else {
       # find bandwidth for these particular range
       rt_range <- range(feature_group[, "rt"])
       bw <- min(max(bandwidth * (max(rt_range) - min(rt_range)), min_bandwidth), max_bandwidth)

--- a/R/recover.weaker.R
+++ b/R/recover.weaker.R
@@ -693,7 +693,7 @@ recover.weaker <- function(filename,
   vec_delta_rt <- compute_delta_rt(times)
 
   sample_intensities <- unlist(dplyr::select(
-    intensity_table %>% dplyr::rename_with(~str_remove(., "_intensity")),
+    intensity_table,
     all_of(sample_name)
   ), use.names = FALSE)
 


### PR DESCRIPTION
This PR solves two issues since both need to update test files and this way it can be done only once.
The test files updated [here](https://gitlab.ics.muni.cz/umsa/umsa-files/-/merge_requests/31) (required to be merged first).

Fixed peak picking corner case when an EIC has between 2 and 10 features.
Close #204.

Removed `_intensity` and `_rt` suffixes from aligned tables.
Close #211.