### PR TITLE
Re-enable parallelism in feature.align.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev] - unreleased
 ### Changed
-- re-enabled parallelism in alignment step []()
+- re-enabled parallelism in alignment step [#230](https://github.com/RECETOX/recetox-aplcms/pull/230)
 
 ## [0.13.3] - 2024-09-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev] - unreleased
+### Changed
+- re-enabled parallelism in alignment step []()
+
 ## [0.13.3] - 2024-09-16
 ### Changed
 - fixed not working eic splitting code [#226](https://github.com/RECETOX/recetox-aplcms/pull/226)

--- a/R/feature.align.R
+++ b/R/feature.align.R
@@ -215,7 +215,7 @@ create_aligned_feature_table <- function(features_table,
   # retention time alignment
   aligned_features <- foreach::foreach(
     i = seq_along(sel.labels), .combine = "comb", .multicombine = TRUE
-  ) %do% {
+  ) %dopar% {
     rows <- create_features_from_cluster(
       dplyr::filter(features_table, cluster == sel.labels[i]),
       mz_tol_relative,


### PR DESCRIPTION
Fixes RECETOX/recetox-aplcms#229

This PR re-introduces the parallelism in the alignment function which got somehow disabled during development.